### PR TITLE
Fix links to point to ardupilot.org

### DIFF
--- a/sphinx_rtd_theme/z_top_menu.html
+++ b/sphinx_rtd_theme/z_top_menu.html
@@ -15,7 +15,7 @@
            
           
            
-           <li><a href='http://firmware.diydrones.com/'>Downloads</a>
+           <li><a href='http://firmware.ardupilot.org/'>Downloads</a>
               <ul>
                 <li><a href='http://firmware.ardupilot.org/Tools/MissionPlanner/'>Mission Planner</a></li>
                 <li><a href='http://firmware.ardupilot.org/Tools/APMPlanner/'>APM Planner 2</a></li>
@@ -32,10 +32,9 @@
               </ul>
            </li>
            
-           <li><a href='#' />Community</a>
+           <li><a href='http://discuss.ardupilot.org' />Community</a>
               <ul>
                  <li><a href='http://discuss.ardupilot.org/'>Forums</a></li>
-                 <li><a href='http://diydrones.com/'>DIY Drones</a></li>
                  <li><a href='{{target}}dev/index.html'>Developer</a></li>
                  {%- if hasdoc('docs/common-commercial-support') %}
                    <li><a title="{{ _('Commercial Support') }}" href="{{ pathto('docs/common-commercial-support') }}">{{ _('Commercial Support') }}</a></li>


### PR DESCRIPTION
Update to fix ardupilot.org links and make forum.ardupilot.org default