### PR TITLE
Fix Tutorial PDFs link

### DIFF
--- a/sphinx_rtd_theme/z_top_menu.html
+++ b/sphinx_rtd_theme/z_top_menu.html
@@ -29,7 +29,7 @@
                  {%- if hasdoc('docs/common-downloads_firmware') %}
                    <li><a title="{{ _('Firmware') }}" href="{{ pathto('docs/common-downloads_firmware') }}">{{ _('Firmware') }}</a></li>
                  {%- endif %}
-                 <li><a href='http://firmware.ardupilot.org/downloads/wiki/pdf_guides/'>Tutorial PDFs</a></li>
+                 <li><a href='http://download.ardupilot.org/downloads/wiki/pdf_guides/'>Tutorial PDFs</a></li>
               </ul>
            </li>
            


### PR DESCRIPTION
I'm not sure we should still be linking to these PDFs but since we are, we should have the correct link.