### PR TITLE
Fix anchor linking

### DIFF
--- a/sass/_sitemenu.sass
+++ b/sass/_sitemenu.sass
@@ -197,7 +197,7 @@
     padding: 13px 25px
     font-size: 13px
 
-    /*border-bottom: 2px #C00000 solid;
+    /*border-bottom: 2px #C00000 solid;*/
 
   #cssmenu ul ul li a
     padding-left: 32px

--- a/sass/_sitemenu.sass
+++ b/sass/_sitemenu.sass
@@ -303,3 +303,15 @@
 
   #cssmenu .submenu-button.submenu-opened:before
     display: none
+
+#jdlogo
+  top: 10px
+  right: 20px
+  position: absolute
+  color: #dddddd
+    
+#jdlogo a:visited a:link
+  color: #9B59B6
+
+#jdlogo a:hover a:active
+  color: #CACACA

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -37,6 +37,10 @@
   //   color: $text-light
   //   vertical-align: super
   //   font-size: 60%
+  
+  .section
+    margin-top: -40px
+    padding-top: 40px
 
   // For the most part, its safe to assume that sphinx wants you to use a blockquote as an indent. It gets
   // used in many different ways, so don't assume you can apply some fancy style, just leave it be.

--- a/sphinx_rtd_theme/z_top_menu.html
+++ b/sphinx_rtd_theme/z_top_menu.html
@@ -78,25 +78,7 @@
            {%- endif %}
         </ul>
         
-<style>
-#jdlogo {
-  top: 10px;
-  right: 20px;
-  position: absolute;
-  color: #dddddd;
-}
-#jdlogo a:visited,
-#jdlogo a:link {
-  color: #9B59B6;
-}
-#jdlogo a:hover,
-#jdlogo a:active {
-  color: #CACACA;
-}
-</style>
-
-<div id=jdlogo>
-Servers by <a href=http://www.jDrones.com/>jDrones</a>
-</div>	
-        
-</div>
+        <div id=jdlogo>
+            Servers by <a href=http://www.jDrones.com/>jDrones</a>
+        </div>
+    </div>


### PR DESCRIPTION
With the site menu, anchor linking works but hides the title:

![captura de ecra 11](https://cloud.githubusercontent.com/assets/1778527/25386894/cb76fe3c-29c0-11e7-8686-e51eaeba0ecd.png)

With this change it should show the title of the section:

![captura de ecra 12](https://cloud.githubusercontent.com/assets/1778527/25386979/10e23324-29c1-11e7-82ab-28234d616ce1.png)

**THIS IS UNTESTED** and unfortunately I did the commit on top of the other PR - so for this one, only last commit matters.