### PR TITLE
Change Corporate doc link to point to Partners

### DIFF
--- a/sphinx_rtd_theme/z_sidebar_additions.html
+++ b/sphinx_rtd_theme/z_sidebar_additions.html
@@ -8,7 +8,7 @@
         </form>
         <br>
         <a href="http://ardupilot.org/copter/docs/common-donation.html">Individual</a>
-        <a href="http://ardupilot.org/copter/docs/common-partners.html">Corporate</a>
+        <a href="http://ardupilot.org/about/Partners">Partners</a>
         <a href="https://shop.ardupilot.org">SWAG Shop</a>
 
         <hr />


### PR DESCRIPTION
As requested by @rmackay9 .
(followed by deletion of  http://ardupilot.org/copter/docs/common-partners.html)