### PR TITLE
z_top_menu: remove Servers by jDrones

### DIFF
--- a/sphinx_rtd_theme/z_top_menu.html
+++ b/sphinx_rtd_theme/z_top_menu.html
@@ -105,8 +105,4 @@
 }
 </style>
 
-<div id=jdlogo>
-Servers by <a href=http://www.jDrones.com/>jDrones</a>
-</div>	
-        
 </div>


### PR DESCRIPTION
I think AP pays for it's own servers now so it's probably best we remove these sponsorship links.

As a side note I'm not sure how to actually test this change but I think we can commit it and then see how it looks and if it goes horribly wrong we can back it out.